### PR TITLE
Stops swarmers from eating the PA or releasing the engine

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -170,15 +170,15 @@
 /obj/structure/particle_accelerator/particle_emitter/right/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, "<span class='warning'>Disrupting the power grid would bring no benefit to us. Aborting.</span>")
 
-/obj/structure/particle_accelerator/particle_emitter/end_cap/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+/obj/structure/particle_accelerator/end_cap/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, "<span class='warning'>Disrupting the power grid would bring no benefit to us. Aborting.</span>")
 
-/obj/structure/particle_accelerator/particle_emitter/power_box/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+/obj/structure/particle_accelerator/power_box/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, "<span class='warning'>Disrupting the power grid would bring no benefit to us. Aborting.</span>")
 
 
-/obj/machinery/field/generator/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
-	S.DisIntegrate(src)
+/obj/machinery/field/generator/swarmer_act(mob/living/simple_animal/hostile/swarmer/S) //Why was eating this explicitly coded in?
+	to_chat(S, "<span class='warning'>An inhospitable area may be created as a result of destroying this object. Aborting.</span>")
 
 /obj/machinery/gravity_generator/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	S.DisIntegrate(src)
@@ -233,7 +233,7 @@
 
 /turf/simulated/wall/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	for(var/turf/T in range(1, src))
-		if(istype(T, /turf/space) || istype(T.loc, /area/space))
+		if(istype(T, /turf/space) || istype(T.loc, /area/space) || istype(T, /turf/simulated/floor/plating/airless)
 			to_chat(S, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			return
 	..()


### PR DESCRIPTION
Attempts to fix https://github.com/ParadiseSS13/Paradise/issues/4456
Fixes the erroneous typepaths that protected two unused machinery objects instead of two actual parts of the PA
Stops swarmers from eating field generators. While it may have been intentional for them to eat the ones in secure storage, they could also eat the ones holding in the engine
Attempts to stop swarmers from accessing the engine (and depressurizing adjacent areas) in the first place. I believe the "no breach" only checking for space turfs (rather than airless plating) was an oversight, as it would allow them to causes breaches in other areas as well.

:cl:HugoLuman
:fix: All parts of the particle accelerator are now protected from swarmers
:fix: Swarmers can no longer release the engine by eating field generators
:fix: Swarmers can no longer cause breaches by eating walls next to roundstart airless floor tiles
/:cl:
